### PR TITLE
Novo comando \refap para apêndices

### DIFF
--- a/00-pacotes.tex
+++ b/00-pacotes.tex
@@ -105,7 +105,7 @@
 	\chapter*{\appendixname\space\space\thechapter~- \uppercase{#1}}%
 	{}
 }
-
+\newcommand{\refap}[1]{\hyperref[#1]{Apêndice~\ref{#1}}} 	% Referência apÊndices
 % uso do tikz e pgfplots
 % ----------------------------------------------------------
 %\usetikzlibrary{external}


### PR DESCRIPTION
Ideia retirada de https://github.com/abntex/abntex2/issues/76.
O comando \autoref{ap:ap02} referencia apêndices com acento agudo: "Apéndice 2".